### PR TITLE
Fix PointerLockControls import

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <div id="crosshair"></div>
     <script type="module">
         import * as THREE from 'https://unpkg.com/three@0.152.2/build/three.module.js';
-        import { PointerLockControls } from 'https://unpkg.com/three@0.152.2/examples/jsm/controls/PointerLockControls.js';
+        import { PointerLockControls } from 'https://unpkg.com/three@0.152.2/examples/jsm/controls/PointerLockControls.js?module';
 
         let scene, camera, renderer, controls;
         let zombies = [];


### PR DESCRIPTION
## Summary
- update PointerLockControls import with `?module` to correctly resolve the `three` dependency

## Testing
- `node --version`